### PR TITLE
Add more dynamic events and player skills

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { Player } from './player.js';
 import { getRandomTeam } from './teams.js';
 import { updateCareerDetails, updateRandomTeamButtons, scrollToBottom, showCareerSummary } from './ui.js';
-import { checkInjury, getRandomGoals, getRandomAssists, showPopup, closePopup, getRandomValueChange, getRandomBallonDorIncrease } from './utils.js';
+import { checkInjury, getRandomGoals, getRandomAssists, showPopup, closePopup, getRandomValueChange, getRandomBallonDorIncrease, checkTrainingBoost, checkTransferInterest, showEventMessage } from './utils.js';
 
 let player = new Player();
 
@@ -61,10 +61,13 @@ function stayTeam() {
     }
 
     player.incrementAge();
+    checkTrainingBoost(player);
     const goals = getRandomGoals();
     const assists = getRandomAssists();
     player.totalGoals += goals;
     player.totalAssists += assists;
+    player.passing += assists * 0.5;
+    checkTransferInterest(player, goals, assists);
 
     let historyColor = 'black';
     let ballonDorMessage = '';
@@ -73,6 +76,7 @@ function stayTeam() {
         player.value += getRandomBallonDorIncrease();
         player.ballonDors++;
         ballonDorMessage = ' - Ballon d\'Or Winner!';
+        showEventMessage("Ballon d'Or winner!");
     } else if (player.value > player.prevValue) {
         historyColor = 'green';
     } else if (player.value < player.prevValue) {
@@ -114,12 +118,15 @@ function chooseTeam(buttonId) {
         return;
     }
     player.incrementAge();
+    checkTrainingBoost(player);
     const chosenTeam = player.nextTeams[buttonId === 'team1' ? 0 : 1];
     player.team = chosenTeam;
     const goals = getRandomGoals();
     const assists = getRandomAssists();
     player.totalGoals += goals;
     player.totalAssists += assists;
+    player.passing += assists * 0.5;
+    checkTransferInterest(player, goals, assists);
 
     let historyColor = 'black';
     let ballonDorMessage = '';
@@ -128,6 +135,7 @@ function chooseTeam(buttonId) {
         player.value += getRandomBallonDorIncrease();
         player.ballonDors++;
         ballonDorMessage = ' - Ballon d\'Or Winner!';
+        showEventMessage("Ballon d'Or winner!");
     } else if (player.value > player.prevValue) {
         historyColor = 'green';
     } else if (player.value < player.prevValue) {

--- a/player.js
+++ b/player.js
@@ -1,4 +1,4 @@
-import { getRandomValueChange, getRandomHighValueIncrease, getRandomHighValueDecrease } from './utils.js';
+import { getRandomValueChange, getRandomHighValueIncrease, getRandomHighValueDecrease, showEventMessage } from './utils.js';
 import { showCareerSummary } from './ui.js';
 
 export class Player {
@@ -25,12 +25,21 @@ export class Player {
         this.injured = false;
         this.injuryDuration = 0;
         this.ballonDors = 0; // Add property to track Ballon d'Or wins
+        this.passing = 50;
+        this.trainingBoostYears = 0;
+        this.transferOffer = false;
     }
 
     incrementAge() {
         this.age++;
         this.totalYears++;
         this.prevValue = this.value;
+
+        if (this.trainingBoostYears > 0) {
+            this.value += 1000000;
+            this.passing += 5;
+            this.trainingBoostYears--;
+        }
 
         if (this.age >= 24 && this.age <= 27) {
             if (Math.random() < 0.20) {
@@ -72,6 +81,11 @@ export class Player {
         const valueDecrease = getRandomValueChange();
         this.value = Math.max(0, this.value - valueDecrease);
 
+        if (this.trainingBoostYears > 0) {
+            this.passing += 5;
+            this.trainingBoostYears--;
+        }
+
         if (this.age > 40) {
             showCareerSummary(this);
         }
@@ -81,26 +95,32 @@ export class Player {
         // League Titles: 25% chance to win once a year
         if (Math.random() < 0.25) {
             this.leagueTitles++;
+            showEventMessage('League Title Won!');
         }
 
         // International Cups: 1% chance to win 3 cups, 15% chance to win 2 cups, 25% chance to win 1 cup
         const internationalChance = Math.random();
         if (internationalChance < 0.01) {
             this.internationalCups += 3;
+            showEventMessage('International Cup Treble!');
         } else if (internationalChance < 0.15) { // 0.05 + 0.20
             this.internationalCups += 2;
+            showEventMessage('International Cup Double!');
         } else if (internationalChance < 0.25) { // 0.05 + 0.20 + 0.30
             this.internationalCups += 1;
+            showEventMessage('International Cup Win!');
         }
 
         // World Cup: 1% chance to win every 4 years
         if (this.age % 4 === 0 && Math.random() < 0.01) {
             this.worldCups++;
+            showEventMessage('World Cup Champion!');
         }
 
         // Continental Cup: 5% chance to win every 4 years
         if (this.age % 4 === 0 && Math.random() < 0.05) {
             this.continentalCups++;
+            showEventMessage('Continental Cup Victory!');
         }
     }
 

--- a/teams.js
+++ b/teams.js
@@ -44,3 +44,13 @@ for (let league in teams) {
 export function getRandomTeam() {
     return allTeams[Math.floor(Math.random() * allTeams.length)];
 }
+
+export const bigTeams = [
+    "Real Madrid", "Barcelona", "Manchester City", "Liverpool",
+    "Bayern Munich", "PSG", "Juventus", "Chelsea", "Manchester United",
+    "Inter Milan", "Milan"
+];
+
+export function getRandomBigTeam() {
+    return bigTeams[Math.floor(Math.random() * bigTeams.length)];
+}

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-import { getRandomTeam } from './teams.js';
+import { getRandomTeam, getRandomBigTeam } from './teams.js';
 import { calculatePerformance, getContinentalCupName } from './utils.js';
 
 export function updateCareerDetails(player) {
@@ -13,7 +13,8 @@ export function updateCareerDetails(player) {
         ${player.age} yrs: ${player.team}<br>
         Value: ${player.value.toLocaleString()} $<br>
         Total Goals: ${player.totalGoals} <br>
-        Total Assists: ${player.totalAssists}
+        Total Assists: ${player.totalAssists} <br>
+        Passing Skill: ${player.passing}
     `;
 
     clubHistory.innerHTML = '';
@@ -30,7 +31,11 @@ export function updateRandomTeamButtons(player) {
         return;
     }
     
-    player.nextTeams = [getRandomTeam(), getRandomTeam()];
+    if (player.transferOffer) {
+        player.nextTeams = [getRandomBigTeam(), getRandomBigTeam()];
+    } else {
+        player.nextTeams = [getRandomTeam(), getRandomTeam()];
+    }
     team1Button.innerText = `Go to ${player.nextTeams[0]}`;
     team2Button.innerText = `Go to ${player.nextTeams[1]}`;
 }
@@ -51,6 +56,7 @@ export function showCareerSummary(player) {
         <p>Highest Value: ${player.highestValue.toLocaleString()} $</p>
         <p>Total Goals: ${player.totalGoals}</p>
         <p>Total Assists: ${player.totalAssists}</p>
+        <p>Passing Skill: ${player.passing}</p>
         <p>League Titles: ${player.leagueTitles}</p>
         <p>International Cups: ${player.internationalCups}</p>
         <p>World Cups: ${player.worldCups}</p>

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,5 @@
+import { getRandomBigTeam } from './teams.js';
+
 export function checkInjury(player) {
     if (Math.random() < 0.01) { // 1% chance of injury
         player.injured = true;
@@ -77,5 +79,46 @@ export function getContinentalCupName(origin) {
             return 'Gold Cup';
         default:
             return 'Continental Cup';
+    }
+}
+
+export function playBeep() {
+    try {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.value = 440;
+        osc.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.2);
+    } catch (e) {}
+}
+
+export function showEventMessage(message) {
+    const div = document.createElement('div');
+    div.className = 'event-message';
+    div.innerText = message;
+    document.body.appendChild(div);
+    playBeep();
+    setTimeout(() => div.classList.add('fade-out'), 2000);
+    setTimeout(() => div.remove(), 3000);
+}
+
+export function checkTrainingBoost(player) {
+    if (Math.random() < 0.05) {
+        player.trainingBoostYears = Math.floor(Math.random() * 2) + 1;
+        showEventMessage(`Training boost! ${player.trainingBoostYears} season(s) of improvement.`);
+        return true;
+    }
+    return false;
+}
+
+export function checkTransferInterest(player, goals, assists) {
+    if ((goals > 25 || assists > 15) && Math.random() < 0.5) {
+        player.transferOffer = true;
+        showEventMessage('Big clubs are interested in you!');
+        player.nextTeams = [getRandomBigTeam(), getRandomBigTeam()];
+    } else {
+        player.transferOffer = false;
     }
 }


### PR DESCRIPTION
## Summary
- introduce bigTeams list for special transfer offers
- add passing skill and training boosts
- display Ballon d'Or and trophy celebrations with event messages
- show training and transfer events in UI
- update team selection to use bigTeams when transfer offer appears

## Testing
- `node --check main.js player.js ui.js utils.js teams.js`

------
https://chatgpt.com/codex/tasks/task_e_68658c7bcb74832da15a5837aaaa9546