### PR TITLE
Add card statistics to career game

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { Player } from './player.js';
 import { getRandomTeam } from './teams.js';
 import { updateCareerDetails, updateRandomTeamButtons, scrollToBottom, showCareerSummary } from './ui.js';
-import { checkInjury, getRandomGoals, getRandomAssists, showPopup, closePopup, getRandomValueChange, getRandomBallonDorIncrease, checkTrainingBoost, checkTransferInterest, showEventMessage } from './utils.js';
+import { checkInjury, getRandomGoals, getRandomAssists, getRandomYellowCards, getRandomRedCards, showPopup, closePopup, getRandomValueChange, getRandomBallonDorIncrease, checkTrainingBoost, checkTransferInterest, showEventMessage } from './utils.js';
 
 let player = new Player();
 
@@ -31,7 +31,7 @@ function startCareer() {
     player.appearance = appearanceInput.value;
 
     player.team = getRandomTeam();
-    player.addClubHistory(player.age, player.team, player.value, 'Initial', 'Initial', 'black');
+    player.addClubHistory(player.age, player.team, player.value, 'Initial', 'Initial', 'black', '', 0, 0);
 
     if (!player.team) {
         showPopup("Error: No team found for the selected origin.");
@@ -64,8 +64,12 @@ function stayTeam() {
     checkTrainingBoost(player);
     const goals = getRandomGoals();
     const assists = getRandomAssists();
+    const yellowCards = getRandomYellowCards();
+    const redCards = getRandomRedCards();
     player.totalGoals += goals;
     player.totalAssists += assists;
+    player.totalYellowCards += yellowCards;
+    player.totalRedCards += redCards;
     player.passing += assists * 0.5;
     checkTransferInterest(player, goals, assists);
 
@@ -83,7 +87,7 @@ function stayTeam() {
         historyColor = 'red';
     }
 
-    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage);
+    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage, yellowCards, redCards);
     updateCareerDetails(player);
     updateRandomTeamButtons(player);
     scrollToBottom('clubHistory');
@@ -92,7 +96,7 @@ function stayTeam() {
 function nextYear() {
     player.injuryDuration--;
     player.incrementAgeDuringInjury();
-    player.addClubHistory(player.age, player.team, player.value, 'Injured', 'Injured', 'black');
+    player.addClubHistory(player.age, player.team, player.value, 'Injured', 'Injured', 'black', '', 0, 0);
 
     if (player.injuryDuration <= 0) {
         player.injured = false;
@@ -119,8 +123,12 @@ function chooseTeam(buttonId) {
     player.team = chosenTeam;
     const goals = getRandomGoals();
     const assists = getRandomAssists();
+    const yellowCards = getRandomYellowCards();
+    const redCards = getRandomRedCards();
     player.totalGoals += goals;
     player.totalAssists += assists;
+    player.totalYellowCards += yellowCards;
+    player.totalRedCards += redCards;
     player.passing += assists * 0.5;
     checkTransferInterest(player, goals, assists);
 
@@ -138,7 +146,7 @@ function chooseTeam(buttonId) {
         historyColor = 'red';
     }
 
-    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage);
+    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage, yellowCards, redCards);
     updateCareerDetails(player);
     updateRandomTeamButtons(player);
     scrollToBottom('clubHistory');

--- a/player.js
+++ b/player.js
@@ -14,6 +14,8 @@ export class Player {
         this.highestValue = 100000;
         this.totalGoals = 0;
         this.totalAssists = 0;
+        this.totalYellowCards = 0;
+        this.totalRedCards = 0;
         this.clubHistory = [];
         this.nextTeams = [];
         this.retired = false;
@@ -119,12 +121,12 @@ export class Player {
         }
     }
 
-    addClubHistory(age, team, value, goals, assists, color, ballonDorMessage = '') {
+    addClubHistory(age, team, value, goals, assists, color, ballonDorMessage = '', yellowCards = 0, redCards = 0) {
         const p = document.createElement('p');
         if (goals === 'Injured' && assists === 'Injured') {
             p.innerText = `${age} yrs: ${team} - ${value.toLocaleString()} $ - Injured`;
         } else {
-            p.innerText = `${age} yrs: ${team} - ${value.toLocaleString()} $ - ${goals} goals - ${assists} assists${ballonDorMessage}`;
+            p.innerText = `${age} yrs: ${team} - ${value.toLocaleString()} $ - ${goals} goals - ${assists} assists - ${yellowCards} YC - ${redCards} RC${ballonDorMessage}`;
         }
         p.style.color = color;
         this.clubHistory.push(p);

--- a/ui.js
+++ b/ui.js
@@ -14,6 +14,8 @@ export function updateCareerDetails(player) {
         Value: ${player.value.toLocaleString()} $<br>
         Total Goals: ${player.totalGoals} <br>
         Total Assists: ${player.totalAssists} <br>
+        Yellow Cards: ${player.totalYellowCards} <br>
+        Red Cards: ${player.totalRedCards} <br>
         Passing Skill: ${player.passing}
     `;
 
@@ -56,6 +58,8 @@ export function showCareerSummary(player) {
         <p>Highest Value: ${player.highestValue.toLocaleString()} $</p>
         <p>Total Goals: ${player.totalGoals}</p>
         <p>Total Assists: ${player.totalAssists}</p>
+        <p>Yellow Cards: ${player.totalYellowCards}</p>
+        <p>Red Cards: ${player.totalRedCards}</p>
         <p>Passing Skill: ${player.passing}</p>
         <p>League Titles: ${player.leagueTitles}</p>
         <p>International Cups: ${player.internationalCups}</p>

--- a/utils.js
+++ b/utils.js
@@ -48,6 +48,28 @@ export function getRandomAssists() {
     }
 }
 
+export function getRandomYellowCards() {
+    const probability = Math.random();
+    if (probability < 0.6) {
+        return Math.floor(Math.random() * 3); // 0-2
+    } else if (probability < 0.9) {
+        return Math.floor(Math.random() * 4) + 3; // 3-6
+    } else {
+        return Math.floor(Math.random() * 5) + 7; // 7-11
+    }
+}
+
+export function getRandomRedCards() {
+    const chance = Math.random();
+    if (chance < 0.85) {
+        return 0;
+    } else if (chance < 0.95) {
+        return 1;
+    } else {
+        return 2;
+    }
+}
+
 export function getRandomBallonDorIncrease() {
     return 10000000 + Math.floor(Math.random() * 40000001);
 }


### PR DESCRIPTION
## Summary
- track yellow and red cards per season
- display yellow/red card totals in career details
- include card counts in career summary

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6866b5d1fef0832d927abdcfc33768e9