### PR TITLE
Enhance player value progression

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { Player } from './player.js';
 import { getRandomTeam } from './teams.js';
 import { updateCareerDetails, updateRandomTeamButtons, scrollToBottom, showCareerSummary } from './ui.js';
-import { checkInjury, getRandomGoals, getRandomAssists, showPopup, closePopup, getRandomValueChange, getRandomBallonDorIncrease, checkTrainingBoost, checkTransferInterest, showEventMessage } from './utils.js';
+import { checkInjury, getGoalsForPosition, getAssistsForPosition, getPassingMultiplier, getRandomYellowCards, getRandomRedCards, showPopup, closePopup, getRandomValueChange, getRandomBallonDorIncrease, checkTrainingBoost, checkTransferInterest, showEventMessage, adjustValueForSeason } from './utils.js';
 
 let player = new Player();
 
@@ -31,7 +31,7 @@ function startCareer() {
     player.appearance = appearanceInput.value;
 
     player.team = getRandomTeam();
-    player.addClubHistory(player.age, player.team, player.value, 'Initial', 'Initial', 'black');
+    player.addClubHistory(player.age, player.team, player.value, 'Initial', 'Initial', 'black', '', 0, 0);
 
     if (!player.team) {
         showPopup("Error: No team found for the selected origin.");
@@ -62,12 +62,17 @@ function stayTeam() {
 
     player.incrementAge();
     checkTrainingBoost(player);
-    const goals = getRandomGoals();
-    const assists = getRandomAssists();
+    const goals = getGoalsForPosition(player.position);
+    const assists = getAssistsForPosition(player.position);
+    const yellowCards = getRandomYellowCards();
+    const redCards = getRandomRedCards();
     player.totalGoals += goals;
     player.totalAssists += assists;
-    player.passing += assists * 0.5;
+    player.totalYellowCards += yellowCards;
+    player.totalRedCards += redCards;
+    player.passing += assists * getPassingMultiplier(player.position);
     checkTransferInterest(player, goals, assists);
+    adjustValueForSeason(player, goals, assists, yellowCards, redCards);
 
     let historyColor = 'black';
     let ballonDorMessage = '';
@@ -83,7 +88,7 @@ function stayTeam() {
         historyColor = 'red';
     }
 
-    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage);
+    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage, yellowCards, redCards);
     updateCareerDetails(player);
     updateRandomTeamButtons(player);
     scrollToBottom('clubHistory');
@@ -92,7 +97,7 @@ function stayTeam() {
 function nextYear() {
     player.injuryDuration--;
     player.incrementAgeDuringInjury();
-    player.addClubHistory(player.age, player.team, player.value, 'Injured', 'Injured', 'black');
+    player.addClubHistory(player.age, player.team, player.value, 'Injured', 'Injured', 'black', '', 0, 0);
 
     if (player.injuryDuration <= 0) {
         player.injured = false;
@@ -117,12 +122,17 @@ function chooseTeam(buttonId) {
     checkTrainingBoost(player);
     const chosenTeam = player.nextTeams[buttonId === 'team1' ? 0 : 1];
     player.team = chosenTeam;
-    const goals = getRandomGoals();
-    const assists = getRandomAssists();
+    const goals = getGoalsForPosition(player.position);
+    const assists = getAssistsForPosition(player.position);
+    const yellowCards = getRandomYellowCards();
+    const redCards = getRandomRedCards();
     player.totalGoals += goals;
     player.totalAssists += assists;
-    player.passing += assists * 0.5;
+    player.totalYellowCards += yellowCards;
+    player.totalRedCards += redCards;
+    player.passing += assists * getPassingMultiplier(player.position);
     checkTransferInterest(player, goals, assists);
+    adjustValueForSeason(player, goals, assists, yellowCards, redCards);
 
     let historyColor = 'black';
     let ballonDorMessage = '';
@@ -138,7 +148,7 @@ function chooseTeam(buttonId) {
         historyColor = 'red';
     }
 
-    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage);
+    player.addClubHistory(player.age, player.team, player.value, goals, assists, historyColor, ballonDorMessage, yellowCards, redCards);
     updateCareerDetails(player);
     updateRandomTeamButtons(player);
     scrollToBottom('clubHistory');

--- a/player.js
+++ b/player.js
@@ -14,6 +14,8 @@ export class Player {
         this.highestValue = 100000;
         this.totalGoals = 0;
         this.totalAssists = 0;
+        this.totalYellowCards = 0;
+        this.totalRedCards = 0;
         this.clubHistory = [];
         this.nextTeams = [];
         this.retired = false;
@@ -93,38 +95,44 @@ export class Player {
     checkTrophies() {
         if (Math.random() < 0.25) {
             this.leagueTitles++;
+            this.value += 2000000;
             showEventMessage('League Title Won!');
         }
 
         const internationalChance = Math.random();
         if (internationalChance < 0.01) {
             this.internationalCups += 3;
+            this.value += 10000000;
             showEventMessage('International Cup Treble!');
         } else if (internationalChance < 0.15) {
             this.internationalCups += 2;
+            this.value += 7000000;
             showEventMessage('International Cup Double!');
         } else if (internationalChance < 0.25) {
             this.internationalCups += 1;
+            this.value += 3000000;
             showEventMessage('International Cup Win!');
         }
 
         if (this.age % 4 === 0 && Math.random() < 0.01) {
             this.worldCups++;
+            this.value += 20000000;
             showEventMessage('World Cup Champion!');
         }
 
         if (this.age % 4 === 0 && Math.random() < 0.05) {
             this.continentalCups++;
+            this.value += 4000000;
             showEventMessage('Continental Cup Victory!');
         }
     }
 
-    addClubHistory(age, team, value, goals, assists, color, ballonDorMessage = '') {
+    addClubHistory(age, team, value, goals, assists, color, ballonDorMessage = '', yellowCards = 0, redCards = 0) {
         const p = document.createElement('p');
         if (goals === 'Injured' && assists === 'Injured') {
             p.innerText = `${age} yrs: ${team} - ${value.toLocaleString()} $ - Injured`;
         } else {
-            p.innerText = `${age} yrs: ${team} - ${value.toLocaleString()} $ - ${goals} goals - ${assists} assists${ballonDorMessage}`;
+            p.innerText = `${age} yrs: ${team} - ${value.toLocaleString()} $ - ${goals} goals - ${assists} assists - ${yellowCards} YC - ${redCards} RC${ballonDorMessage}`;
         }
         p.style.color = color;
         this.clubHistory.push(p);

--- a/ui.js
+++ b/ui.js
@@ -14,6 +14,8 @@ export function updateCareerDetails(player) {
         Value: ${player.value.toLocaleString()} $<br>
         Total Goals: ${player.totalGoals} <br>
         Total Assists: ${player.totalAssists} <br>
+        Yellow Cards: ${player.totalYellowCards} <br>
+        Red Cards: ${player.totalRedCards} <br>
         Passing Skill: ${player.passing}
     `;
 
@@ -56,6 +58,8 @@ export function showCareerSummary(player) {
         <p>Highest Value: ${player.highestValue.toLocaleString()} $</p>
         <p>Total Goals: ${player.totalGoals}</p>
         <p>Total Assists: ${player.totalAssists}</p>
+        <p>Yellow Cards: ${player.totalYellowCards}</p>
+        <p>Red Cards: ${player.totalRedCards}</p>
         <p>Passing Skill: ${player.passing}</p>
         <p>League Titles: ${player.leagueTitles}</p>
         <p>International Cups: ${player.internationalCups}</p>

--- a/utils.js
+++ b/utils.js
@@ -26,25 +26,126 @@ export function getRandomHighValueDecrease() {
     return 10000000 + Math.floor(Math.random() * 11000001);
 }
 
-export function getRandomGoals() {
-    const probability = Math.random();
-    if (probability < 0.80) {
-        return Math.floor(Math.random() * 11);
-    } else if (probability < 0.95) {
-        return Math.floor(Math.random() * 31);
-    } else {
-        return Math.floor(Math.random() * 101);
+export function getGoalsForPosition(position) {
+    const prob = Math.random();
+    switch (position) {
+        case 'GK':
+            return prob < 0.01 ? 1 : 0;
+        case 'CB':
+        case 'RB':
+        case 'LB':
+        case 'RWB':
+        case 'LWB':
+            if (prob < 0.8) return Math.floor(Math.random() * 3); // 0-2
+            if (prob < 0.95) return Math.floor(Math.random() * 6); // 0-5
+            return Math.floor(Math.random() * 11); // 0-10
+        case 'CDM':
+        case 'CM':
+        case 'RM':
+        case 'LM':
+            if (prob < 0.8) return Math.floor(Math.random() * 6); // 0-5
+            if (prob < 0.95) return Math.floor(Math.random() * 11); // 0-10
+            return Math.floor(Math.random() * 21); // 0-20
+        case 'CAM':
+        case 'ST':
+        case 'CF':
+        case 'RW':
+        case 'LW':
+        default:
+            if (prob < 0.8) return Math.floor(Math.random() * 16); // 0-15
+            if (prob < 0.95) return Math.floor(Math.random() * 26); // 0-25
+            return Math.floor(Math.random() * 41); // 0-40
     }
 }
 
-export function getRandomAssists() {
+export function getAssistsForPosition(position) {
+    const prob = Math.random();
+    switch (position) {
+        case 'GK':
+            return prob < 0.05 ? 1 : 0;
+        case 'CB':
+        case 'RB':
+        case 'LB':
+        case 'RWB':
+        case 'LWB':
+            if (prob < 0.8) return Math.floor(Math.random() * 3); // 0-2
+            if (prob < 0.95) return Math.floor(Math.random() * 6); // 0-5
+            return Math.floor(Math.random() * 11); // 0-10
+        case 'CDM':
+        case 'CM':
+        case 'RM':
+        case 'LM':
+            if (prob < 0.8) return Math.floor(Math.random() * 8); // 0-7
+            if (prob < 0.95) return Math.floor(Math.random() * 16); // 0-15
+            return Math.floor(Math.random() * 26); // 0-25
+        case 'CAM':
+        case 'ST':
+        case 'CF':
+        case 'RW':
+        case 'LW':
+        default:
+            if (prob < 0.8) return Math.floor(Math.random() * 6); // 0-5
+            if (prob < 0.95) return Math.floor(Math.random() * 11); // 0-10
+            return Math.floor(Math.random() * 16); // 0-15
+    }
+}
+
+export function getPassingMultiplier(position) {
+    switch (position) {
+        case 'GK':
+            return 0.1;
+        case 'CB':
+        case 'RB':
+        case 'LB':
+        case 'RWB':
+        case 'LWB':
+            return 0.2;
+        case 'CDM':
+        case 'CM':
+        case 'CAM':
+        case 'RM':
+        case 'LM':
+            return 0.6;
+        case 'ST':
+        case 'CF':
+        case 'RW':
+        case 'LW':
+        default:
+            return 0.4;
+    }
+}
+
+export function getRandomYellowCards() {
     const probability = Math.random();
-    if (probability < 0.80) {
-        return Math.floor(Math.random() * 6);
-    } else if (probability < 0.95) {
-        return Math.floor(Math.random() * 16);
+    if (probability < 0.6) {
+        return Math.floor(Math.random() * 3); // 0-2
+    } else if (probability < 0.9) {
+        return Math.floor(Math.random() * 4) + 3; // 3-6
     } else {
-        return Math.floor(Math.random() * 31);
+        return Math.floor(Math.random() * 5) + 7; // 7-11
+    }
+}
+
+export function getRandomRedCards() {
+    const chance = Math.random();
+    if (chance < 0.85) {
+        return 0;
+    } else if (chance < 0.95) {
+        return 1;
+    } else {
+        return 2;
+    }
+}
+
+export function adjustValueForSeason(player, goals, assists, yellowCards, redCards) {
+    let change = goals * 200000 + assists * 150000;
+    change -= yellowCards * 50000 + redCards * 200000;
+    if (player.transferOffer) {
+        change *= 1.2;
+    }
+    player.value = Math.max(0, player.value + Math.floor(change));
+    if (player.value > player.highestValue) {
+        player.highestValue = player.value;
     }
 }
 


### PR DESCRIPTION
## Summary
- tune trophy logic to boost player value with wins
- add `adjustValueForSeason` helper to modify value using goals, assists and cards
- call the new helper when staying or transferring to a team
- vary goals, assists and passing growth by player position

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6866b5d1fef0832d927abdcfc33768e9