### PR TITLE
Add contract years left system

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ function startCareer() {
     player.appearance = appearanceInput.value;
 
     player.team = getRandomTeam();
+    player.signNewContract();
     player.addClubHistory(player.age, player.team, player.value, 'Initial', 'Initial', 'black', '', 0, 0);
 
     if (!player.team) {
@@ -125,6 +126,7 @@ function chooseTeam(buttonId) {
     checkTrainingBoost(player);
     const chosenTeam = player.nextTeams[buttonId === 'team1' ? 0 : 1];
     player.team = chosenTeam;
+    player.signNewContract();
     const goals = getGoalsForPosition(player.position);
     const assists = getAssistsForPosition(player.position);
 

--- a/player.js
+++ b/player.js
@@ -1,4 +1,4 @@
-import { getRandomValueChange, getRandomHighValueIncrease, getRandomHighValueDecrease, showEventMessage } from './utils.js';
+import { getRandomValueChange, getRandomHighValueIncrease, getRandomHighValueDecrease, showEventMessage, getContractLengthForAge } from './utils.js';
 import { showCareerSummary } from './ui.js';
 
 export class Player {
@@ -30,12 +30,17 @@ export class Player {
         this.passing = 50;
         this.trainingBoostYears = 0;
         this.transferOffer = false;
+        this.contractYearsLeft = 0;
     }
 
     incrementAge() {
         this.age++;
         this.totalYears++;
         this.prevValue = this.value;
+        this.contractYearsLeft--;
+        if (this.contractYearsLeft <= 0) {
+            this.signNewContract();
+        }
 
         if (this.trainingBoostYears > 0) {
             this.value += 1000000;
@@ -79,6 +84,10 @@ export class Player {
         this.age++;
         this.totalYears++;
         this.prevValue = this.value;
+        this.contractYearsLeft--;
+        if (this.contractYearsLeft <= 0) {
+            this.signNewContract();
+        }
         const valueDecrease = getRandomValueChange();
         this.value = Math.max(0, this.value - valueDecrease);
 
@@ -136,5 +145,10 @@ export class Player {
         }
         p.style.color = color;
         this.clubHistory.push(p);
+    }
+
+    signNewContract() {
+        this.contractYearsLeft = getContractLengthForAge(this.age);
+        showEventMessage(`Signed a ${this.contractYearsLeft}-year contract with ${this.team}`);
     }
 }

--- a/ui.js
+++ b/ui.js
@@ -12,6 +12,7 @@ export function updateCareerDetails(player) {
     careerDetails.innerHTML = `
         ${player.age} yrs: ${player.team}<br>
         Value: ${player.value.toLocaleString()} $<br>
+        Contract Years Left: ${player.contractYearsLeft}<br>
         Total Goals: ${player.totalGoals} <br>
         Total Assists: ${player.totalAssists} <br>
         Yellow Cards: ${player.totalYellowCards} <br>
@@ -61,6 +62,7 @@ export function showCareerSummary(player) {
         <p>Yellow Cards: ${player.totalYellowCards}</p>
         <p>Red Cards: ${player.totalRedCards}</p>
         <p>Passing Skill: ${player.passing}</p>
+        <p>Contract Years Left: ${player.contractYearsLeft}</p>
         <p>League Titles: ${player.leagueTitles}</p>
         <p>International Cups: ${player.internationalCups}</p>
         <p>World Cups: ${player.worldCups}</p>

--- a/utils.js
+++ b/utils.js
@@ -245,3 +245,17 @@ export function checkTransferInterest(player, goals, assists) {
         player.transferOffer = false;
     }
 }
+
+export function getContractLengthForAge(age) {
+    if (age < 21) {
+        return Math.floor(Math.random() * 3) + 5; // 5-7 years
+    } else if (age < 26) {
+        return Math.floor(Math.random() * 3) + 4; // 4-6 years
+    } else if (age < 31) {
+        return Math.floor(Math.random() * 3) + 3; // 3-5 years
+    } else if (age < 35) {
+        return Math.floor(Math.random() * 2) + 2; // 2-3 years
+    } else {
+        return Math.floor(Math.random() * 2) + 1; // 1-2 years
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `contractYearsLeft` mechanic with age-based renewal
- display contract duration in career details and summary
- reset contract when starting or transferring teams
- auto-renew contracts as seasons pass

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866c038e4a4832d83d1f49b8e978acd